### PR TITLE
Create custom field endpoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "psr/http-message": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "php-http/httplug": "^2.0",

--- a/lib/Dmm/Client.php
+++ b/lib/Dmm/Client.php
@@ -7,11 +7,11 @@ use Dmm\Helpers\DiscoverApi;
 use Dmm\HttpClient\Api\AbstractApi;
 use Dmm\HttpClient\Builder;
 use Http\Client\Common\HttpMethodsClientInterface;
-use Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin\AuthenticationPlugin;
+use Http\Client\Common\Plugin\BaseUriPlugin;
+use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Message\Authentication\Bearer;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 final class Client
@@ -52,8 +52,8 @@ final class Client
 
     private function initDefaultPlugins(): void
     {
-        $this->httpClientBuilder->addPlugin(new Plugin\AddHostPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri('https://jsonplaceholder.typicode.com')));
-        $this->httpClientBuilder->addPlugin(new Plugin\HeaderDefaultsPlugin([
+        $this->httpClientBuilder->addPlugin(new BaseUriPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.directmailmanager.com/api')));
+        $this->httpClientBuilder->addPlugin(new HeaderDefaultsPlugin([
             'User-Agent' => 'php-dmm-api ()',
             'Content-Type' => 'application/json',
             'Accept' => 'application/json',

--- a/lib/Dmm/Helpers/DiscoverApi.php
+++ b/lib/Dmm/Helpers/DiscoverApi.php
@@ -39,7 +39,7 @@ class DiscoverApi
                 continue;
             }
 
-            $apiObjects[strtolower($ref->getShortName())] = $ref->name;
+            $apiObjects[lcfirst($ref->getShortName())] = $ref->name;
 
 
         }

--- a/lib/Dmm/HttpClient/Api/CustomFields.php
+++ b/lib/Dmm/HttpClient/Api/CustomFields.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Dmm\HttpClient\Api;
+
+class CustomFields extends AbstractApi
+{
+    /**
+     * @link https://apidocs.directmailmanager.com/docs/dmm-v3-api/b3A6MjU4MTE3NDY-list-all-custom-fields
+     */
+    public function list(array $params = []): array|string
+    {
+        return $this->get('/custom-fields', $params);
+    }
+
+    /**
+     * @link https://apidocs.directmailmanager.com/docs/dmm-v3-api/b3A6MjU4MTE3NDg-retrieve-a-custom-field
+     */
+    public function retrieve(string $id, array $params = []): array|string
+    {
+        return $this->get("/custom-fields/$id", $params);
+    }
+
+    /**
+     * @link https://apidocs.directmailmanager.com/docs/dmm-v3-api/b3A6MjU4MTE3NDc-create-a-custom-field
+     */
+    public function create(array $params = []): array|string
+    {
+        return $this->post('/custom-fields', $params);
+    }
+
+    /**
+     * @link https://apidocs.directmailmanager.com/docs/dmm-v3-api/b3A6MjU4MTE3NDk-update-a-custom-field
+     */
+    public function update(string $id, array $params = []): array|string
+    {
+        return $this->put("/custom-fields/$id", $params);
+    }
+
+    /**
+     * @link https://apidocs.directmailmanager.com/docs/dmm-v3-api/b3A6MjU4MTE3NTA-delete-a-custom-field
+     */
+    public function destroy(string $id): array|string
+    {
+        return $this->delete("/custom-fields/$id");
+    }
+}


### PR DESCRIPTION
New methods for the custom fields:
- list
- retrieve
- create
- update
- destroy

An example of usage:
`$sdk->customFields()->list()`